### PR TITLE
Add missing Capawesome plugins

### DIFF
--- a/scripts/source-data/plugins.txt
+++ b/scripts/source-data/plugins.txt
@@ -99,9 +99,15 @@
 @capacitor/storage
 @capacitor/text-zoom
 @capacitor/toast
+@capawesome-team/capacitor-android-battery-optimization
+@capawesome-team/capacitor-android-foreground-service
+@capawesome-team/capacitor-datetime-picker
+@capawesome-team/capacitor-file-opener
+@capawesome-team/capacitor-nfc
 @capawesome/capacitor-app-update
 @capawesome/capacitor-background-task
 @capawesome/capacitor-badge
+@capawesome/capacitor-cloudinary
 @capawesome/capacitor-file-picker
 @capawesome/capacitor-managed-configurations
 @capawesome/capacitor-photo-editor


### PR DESCRIPTION
This PR adds the missing Capawesome plugins, see https://capawesome.io/plugins/.