### PR TITLE
chore: add capacitor reminder plugin

### DIFF
--- a/scripts/source-data/plugins.txt
+++ b/scripts/source-data/plugins.txt
@@ -1149,3 +1149,4 @@ wonderpush-cordova-sdk
 wonderpush-cordova-sdk-fcm
 wxs-chris-wxsnetwork
 zebra-capacitor
+@bazuka5801/capacitor-reminders


### PR DESCRIPTION
This PR adds the missing @bazuka5801/capacitor-reminders plugin, see https://github.com/bazuka5801/capacitor-reminders