### PR TITLE
fix(types): More accurate platform and author types

### DIFF
--- a/scripts/fetch-from-npm.ts
+++ b/scripts/fetch-from-npm.ts
@@ -15,7 +15,7 @@ export async function applyNpmInfo(plugin: PluginInfo) {
     // Likely not found in npm
     return;
   }
-  
+
   plugin.version = npmHistory.version;
   plugin.versions = npmHistory.versions as string[];
   plugin.author = npmHistory.author;
@@ -29,7 +29,8 @@ export async function applyNpmInfo(plugin: PluginInfo) {
   plugin.repo = cleanUrl(npmHistory.repository?.url);
   plugin.keywords = npmHistory.keywords;
   if (npmLatest.cordova) {
-    plugin.platforms = npmLatest.cordova.platforms;
+    const platforms = npmLatest.cordova.platforms;
+    plugin.platforms = Array.isArray(platforms) ? platforms : [platforms];
   }
   if (npmLatest.capacitor) {
     plugin.platforms = [];

--- a/scripts/format-results.ts
+++ b/scripts/format-results.ts
@@ -1,7 +1,7 @@
 import jsonfile from "jsonfile";
 import path from "path";
 import fs from "fs";
-import { PluginResult } from "../shared/plugin-result";
+import { PluginResult, PluginType } from "../shared/plugin-result";
 import { searchKeys } from "../shared/search-keys";
 import { calculatePluginScore } from "./calculate-score";
 import { PluginInfo } from "./types/plugin";
@@ -27,6 +27,7 @@ export async function writePluginDataToPublicDirectory(
       health: calculatePluginScore(plugin),
       platforms: plugin.platforms,
       author: plugin.author,
+      type: getPluginType(plugin),
       stats: {
         downloads: plugin.downloads ?? -1,
         downloadsStart: plugin.downloadStart,
@@ -93,4 +94,10 @@ function createSearchIndex(pluginData: PluginResult[], savePath: string) {
       }
     });
   });
+}
+
+function getPluginType({ name }: PluginInfo): PluginType {
+  return name.startsWith("@capacitor/") || name.startsWith("@ionic-enterprise/")
+    ? "official"
+    : "community";
 }

--- a/scripts/format-results.ts
+++ b/scripts/format-results.ts
@@ -25,6 +25,8 @@ export async function writePluginDataToPublicDirectory(
       lastUpdated: plugin.published,
       githubUrl: plugin.repo,
       health: calculatePluginScore(plugin),
+      platforms: plugin.platforms,
+      author: plugin.author,
       stats: {
         downloads: plugin.downloads ?? -1,
         downloadsStart: plugin.downloadStart,
@@ -32,6 +34,7 @@ export async function writePluginDataToPublicDirectory(
         downloadsPeriod: plugin.downloadPeriod,
         stars: plugin.stars,
         openIssues: plugin.issues,
+        watchers: plugin.watchers,
       },
     };
     return pluginResult;

--- a/scripts/summary.ts
+++ b/scripts/summary.ts
@@ -87,7 +87,7 @@ export function readPlugin(plugin: string): PluginInfo {
     description: "",
     success: [],
     repo: "",
-    author: "",
+    author: { name: "", email: "" },
     published: "",
     versions: [],
     keywords: [],
@@ -125,7 +125,7 @@ function cleanupPlugin(i: PluginInfo): PluginInfo {
     i.name?.startsWith("@capacitor/") ||
     i.name?.startsWith("@ionic-enterprise/")
   ) {
-    i.author = "Ionic";
+    i.author = { name: "Ionic" };
     if (!i.image) {
       i.image = "https://avatars.githubusercontent.com/u/3171503?v=4";
     }

--- a/scripts/types/npm-data-schema.ts
+++ b/scripts/types/npm-data-schema.ts
@@ -14,7 +14,7 @@ export interface NpmInfo {
   homepage: string;
   keywords: string[];
   repository: Repository;
-  author: string;
+  author: { name: string; email?: string };
   bugs: Bugs;
   license: string;
   readmeFilename: string;
@@ -45,7 +45,7 @@ export interface NpmInfo {
 }
 
 interface CordovaInfo {
-  platforms: string[];
+  platforms: string[] | string;
 }
 
 interface CapacitorInfo {

--- a/scripts/types/plugin.ts
+++ b/scripts/types/plugin.ts
@@ -6,7 +6,7 @@
  */
 export interface PluginInfo {
   name: string; // Name of the npm package
-  author: string; // Name of the Author of the latest package
+  author: { name: string; email?: string }; // Name and email of the Author of the latest package
   published: string; // Date Time published to npm
   license: string; // eg MIT
   version: string; // Version number inspected from NPM

--- a/shared/plugin-result.ts
+++ b/shared/plugin-result.ts
@@ -8,6 +8,7 @@ export type PluginResult = {
   githubUrl: string | undefined;
   platforms: string[];
   author: { name: string; email?: string };
+  type: PluginType;
   health: {
     score: number;
     modifiers: string[];
@@ -22,3 +23,5 @@ export type PluginResult = {
     openIssues: number;
   };
 };
+
+export type PluginType = "official" | "community";

--- a/shared/plugin-result.ts
+++ b/shared/plugin-result.ts
@@ -6,6 +6,8 @@ export type PluginResult = {
   license: string;
   lastUpdated: string;
   githubUrl: string | undefined;
+  platforms: string[];
+  author: { name: string; email?: string };
   health: {
     score: number;
     modifiers: string[];
@@ -16,6 +18,7 @@ export type PluginResult = {
     downloadsEnd: string | undefined;
     downloadsPeriod: string | undefined;
     stars?: number;
+    watchers: number;
     openIssues: number;
   };
 };


### PR DESCRIPTION
This commit adds:
- handling of string "platform" types for Cordova in addition to array
- object author type with name and email instead of string to conform to NPM response
- stars, watchers, and platforms to plugin data
- plugin type to differentiate between community and official plugins