### PR TITLE
chore(scripts): public plugin data

### DIFF
--- a/scripts/format-results.ts
+++ b/scripts/format-results.ts
@@ -11,7 +11,8 @@ import { normalizeStringArray } from "./utils";
 export async function writePluginDataToPublicDirectory(
   pluginData: PluginInfo[]
 ) {
-  const PLUGIN_PUBLIC_DATA_PATH = path.join("data", "plugin-data.json");
+  const PLUGIN_DATA_PATH = path.join("data", "plugin-data.json");
+  const PLUGIN_PUBLIC_DATA_PATH = path.join("public", "plugin-data.json");
   const PLUGIN_PUBLIC_RAW_PATH = path.join("public", "plugin-data-raw.json");
   const PLUGIN_INDEX_DATA_PATH = path.join("data", "plugin-index.json");
 
@@ -41,9 +42,11 @@ export async function writePluginDataToPublicDirectory(
     return pluginResult;
   });
 
+  await deleteFileIfExists(PLUGIN_DATA_PATH);
   await deleteFileIfExists(PLUGIN_PUBLIC_DATA_PATH);
   await deleteFileIfExists(PLUGIN_PUBLIC_RAW_PATH);
   await deleteFileIfExists(PLUGIN_INDEX_DATA_PATH);
+  await writeDataFile(pluginResults, PLUGIN_DATA_PATH);
   await writeDataFile(pluginResults, PLUGIN_PUBLIC_DATA_PATH);
   await writeDataFile(pluginData, PLUGIN_PUBLIC_RAW_PATH);
   await createSearchIndex(pluginResults, PLUGIN_INDEX_DATA_PATH);


### PR DESCRIPTION
This writes `plugin-data.json` to the public folder so it is hosted on the live site. The way things are set up now, it would be available at https://capacitorjs.com/directory/plugin-data.json. It would be useful to have access to this file during build time in the capacitor site.