### PR TITLE
Better author, license, and plugin types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# public
+public/plugin-data-raw.json
+public/plugin-data.json

--- a/scripts/fetch-from-npm.ts
+++ b/scripts/fetch-from-npm.ts
@@ -18,10 +18,7 @@ export async function applyNpmInfo(plugin: PluginInfo) {
 
   plugin.version = npmHistory.version;
   plugin.versions = npmHistory.versions as string[];
-  plugin.author =
-    typeof npmHistory.author === "string"
-      ? { name: npmHistory.author }
-      : npmHistory.author;
+  plugin.author = npmHistory.author;
   plugin.description = npmHistory.description;
   plugin.bugs = npmHistory.bugs?.url;
   plugin.published = npmHistory.time[npmHistory.version];

--- a/scripts/format-results.ts
+++ b/scripts/format-results.ts
@@ -6,7 +6,11 @@ import { searchKeys } from "../shared/search-keys";
 import { calculatePluginScore } from "./calculate-score";
 import { PluginInfo } from "./types/plugin";
 import Fuse from "fuse.js";
-import { normalizeStringArray } from "./utils";
+import {
+  normalizeAuthor,
+  normalizeLicense,
+  normalizeStringArray,
+} from "./utils";
 
 export async function writePluginDataToPublicDirectory(
   pluginData: PluginInfo[]
@@ -22,12 +26,12 @@ export async function writePluginDataToPublicDirectory(
       npmPackageName: plugin.name,
       description: plugin.description,
       keywords: normalizeStringArray(plugin.keywords),
-      license: plugin.license,
+      license: normalizeLicense(plugin.license),
       lastUpdated: plugin.published,
       githubUrl: plugin.repo,
       health: calculatePluginScore(plugin),
       platforms: plugin.platforms,
-      author: plugin.author,
+      author: normalizeAuthor(plugin.author),
       type: getPluginType(plugin),
       stats: {
         downloads: plugin.downloads ?? -1,

--- a/scripts/types/npm-data-schema.ts
+++ b/scripts/types/npm-data-schema.ts
@@ -14,9 +14,9 @@ export interface NpmInfo {
   homepage: string;
   keywords: string[];
   repository: Repository;
-  author: { name: string; email?: string } | string;
+  author: { name: string; email?: string; url?: string } | string;
   bugs: Bugs;
-  license: string;
+  license: { type: string; url?: string } | string;
   readmeFilename: string;
   _cached: boolean;
   _contentLength: number;

--- a/scripts/types/plugin.ts
+++ b/scripts/types/plugin.ts
@@ -1,3 +1,5 @@
+import { NpmInfo } from "./npm-data-schema";
+
 /**
  * This interface is the output from inspecting all plugins mentioned in plugins.txt
  * It is used by the plugin explorer in the VS Code extension
@@ -5,13 +7,13 @@
  * You can use shared/plugin-result for the plugin registry and modify it to suite needs
  */
 export interface PluginInfo {
-  name: string; // Name of the npm package
-  author: { name: string; email?: string }; // Name and email of the Author of the latest package
+  name: NpmInfo["name"]; // Name of the npm package
+  author: NpmInfo["author"]; // Name and email of the Author of the latest package
   published: string; // Date Time published to npm
-  license: string; // eg MIT
-  version: string; // Version number inspected from NPM
-  versions: string[]; // List of version numbers available (NPM)
-  keywords: string[]; // List of keywords from npm and Github filtered to remove garbage
+  license: NpmInfo["license"]; // eg MIT
+  version: NpmInfo["version"]; // Version number inspected from NPM
+  versions: NpmInfo["versions"]; // List of version numbers available (NPM)
+  keywords: NpmInfo["keywords"]; // List of keywords from npm and Github filtered to remove garbage
   repo: string | undefined; // Url to the github repo (if open source)
   success: string[]; // List of string of environments where this plugin will fail (eg cordova-android-11)
   fails: string[]; // List of string of environments where this plugin will fail (eg capacitor-ios-5)

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -2,6 +2,7 @@ import fetch from "cross-fetch";
 import chalk from "chalk";
 import fs from "fs";
 import path from "path";
+import { NpmInfo } from "./types/npm-data-schema";
 
 export function patchConsole() {
   const originalConsoleError = console.error;
@@ -38,6 +39,14 @@ export function sleep(ms: number) {
 export function normalizeStringArray(arr?: string[]) {
   if (!arr || !Array.isArray(arr)) return [];
   return Array.from(new Set(arr.map((s) => s.toLowerCase().trim())));
+}
+
+export function normalizeAuthor(author: NpmInfo["author"]) {
+  return typeof author === "string" ? { name: author } : author;
+}
+
+export function normalizeLicense(license: NpmInfo["license"]) {
+  return typeof license === "string" ? { type: license } : license;
 }
 
 export function createDataDirectoryIfNotExists() {

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 import fs from "fs";
 import path from "path";
 import { NpmInfo } from "./types/npm-data-schema";
+import { PluginResult } from "../shared/plugin-result";
 
 export function patchConsole() {
   const originalConsoleError = console.error;
@@ -41,11 +42,11 @@ export function normalizeStringArray(arr?: string[]) {
   return Array.from(new Set(arr.map((s) => s.toLowerCase().trim())));
 }
 
-export function normalizeAuthor(author: NpmInfo["author"]) {
+export function normalizeAuthor(author: PluginResult["author"]) {
   return typeof author === "string" ? { name: author } : author;
 }
 
-export function normalizeLicense(license: NpmInfo["license"]) {
+export function normalizeLicense(license: PluginResult["license"]) {
   return typeof license === "string" ? { type: license } : license;
 }
 

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -2,7 +2,7 @@ import fetch from "cross-fetch";
 import chalk from "chalk";
 import fs from "fs";
 import path from "path";
-import { NpmInfo } from "./types/npm-data-schema";
+import { PluginInfo } from "./types/plugin";
 
 export function patchConsole() {
   const originalConsoleError = console.error;
@@ -41,11 +41,11 @@ export function normalizeStringArray(arr?: string[]) {
   return Array.from(new Set(arr.map((s) => s.toLowerCase().trim())));
 }
 
-export function normalizeAuthor(author: NpmInfo["author"]) {
+export function normalizeAuthor(author: PluginInfo["author"]) {
   return typeof author === "string" ? { name: author } : author;
 }
 
-export function normalizeLicense(license: NpmInfo["license"]) {
+export function normalizeLicense(license: PluginInfo["license"]) {
   return typeof license === "string" ? { type: license } : license;
 }
 

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -3,7 +3,6 @@ import chalk from "chalk";
 import fs from "fs";
 import path from "path";
 import { NpmInfo } from "./types/npm-data-schema";
-import { PluginResult } from "../shared/plugin-result";
 
 export function patchConsole() {
   const originalConsoleError = console.error;
@@ -42,11 +41,11 @@ export function normalizeStringArray(arr?: string[]) {
   return Array.from(new Set(arr.map((s) => s.toLowerCase().trim())));
 }
 
-export function normalizeAuthor(author: PluginResult["author"]) {
+export function normalizeAuthor(author: NpmInfo["author"]) {
   return typeof author === "string" ? { name: author } : author;
 }
 
-export function normalizeLicense(license: PluginResult["license"]) {
+export function normalizeLicense(license: NpmInfo["license"]) {
   return typeof license === "string" ? { type: license } : license;
 }
 

--- a/shared/plugin-result.ts
+++ b/shared/plugin-result.ts
@@ -3,11 +3,11 @@ export type PluginResult = {
   npmPackageName: string;
   description: string;
   keywords: string[];
-  license: string;
+  license: { type: string; url?: string };
   lastUpdated: string;
   githubUrl: string | undefined;
   platforms: string[];
-  author: { name: string; email?: string };
+  author: { name: string; email?: string; url?: string };
   type: PluginType;
   health: {
     score: number;


### PR DESCRIPTION
This PR includes:
- adding public plugin data files to gitignore
- normalize author type to accommodate `object` or `string` type coming from NPM
- normalize license type to accommodate `object` or `string` type coming from NPM
- better `PluginInfo` types by referencing `NpmInfo` instead of restating types