### PR TITLE
ci(deploy-production): run only if the repo is named `ionic-team/capacitor-plugin-registry`

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   deploy:
+    if: github.repository == 'ionic-team/capacitor-plugin-registry'
     environment:
       name: production
       url: https://capacitorjs.com/directory


### PR DESCRIPTION
Currently, you get a failing workflow in your fork every day. This prevents the job from running in forks that don't have permissions anyway.