### PR TITLE
fix: reduce outputted json file

### DIFF
--- a/scripts/summary.ts
+++ b/scripts/summary.ts
@@ -39,6 +39,8 @@ async function inspectPlugin(name: string): Promise<PluginInfo> {
   if (plugin.repo?.includes("github.com")) {
     await applyGithubInfo(plugin);
   }
+  // Important: We dont need all the data that comes from npm so set versions to []
+  plugin.versions = [];
   return plugin;
 }
 


### PR DESCRIPTION
The versions property gets a very object large payload dumped into it from npm. It is supposed to be a string array of version numbers (but isn't actually used).

This PR reduces the JSON payload size from ~186mb to less than 2mb